### PR TITLE
Fix coverage calculation to reduce false positives

### DIFF
--- a/src/get_reads.py
+++ b/src/get_reads.py
@@ -53,7 +53,6 @@ def make_barcodeDict(chrom):
 	disc_mate_pairs = dict()
 	split_reads = collections.defaultdict(list)
 	LRs_by_pos = collections.defaultdict(list)
-	lengths = sum(reads.lengths)
 	iterator = reads.fetch(chrom)
 	starttime = time.time()
 	prevtime = starttime

--- a/src/global_vars.py
+++ b/src/global_vars.py
@@ -77,6 +77,9 @@ def estimate_lmin_lmax():
 	num = 0
 	for i,chrm in enumerate(reads.references):
 		for read in reads.fetch(chrm):
+			if read.is_unmapped or read.mate_is_unmapped:
+				continue
+
 			num += 1
 			if num > 1000000:
 				break
@@ -84,10 +87,8 @@ def estimate_lmin_lmax():
 				if read.reference_start > mate_pairs[read.query_name][0]:
 					dist = read.reference_start-mate_pairs[read.query_name][1]
 				else:
-					try:
-						dist = mate_pairs[read.query_name][0]-read.reference_end
-					except:
-						pass
+					dist = mate_pairs[read.query_name][0]-read.reference_end
+
 				if abs(dist) < 2000:
 					length.append(read.query_length)
 					ls.append(dist)


### PR DESCRIPTION
The current coverage calculation is using the **total genome length** to calculate the mean chromosome coverage. Instead the **chromosome length** should be used.  This is also calculated on line [47](https://github.com/raphael-group/NAIBR/blob/e55beaff502ff48c7ad6941065ffe72aa46eda08/src/get_reads.py#L47)  but for whatever reason overwritten by the total genome length value which is removed in this PR. 

The error means that for each chromosome the coverage has been calculated too low. Furthermore since the coverage is used to calculate the threshold for calling candidates as "PASS" or "FAIL", this threshold has been calculate too low. This would in turn lead to the higher false positive rates if relying on "PASS" entries. 

Note that this PR should follow #20. 